### PR TITLE
use socket2 for sockaddr conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ am = ["tokio/sync", "crossbeam"]
 
 [dependencies]
 ucx1-sys = { version = "0.1", path = "ucx1-sys" }
-os_socketaddr = "0.1"
+socket2 = "0.4"
 futures = "0.3"
 futures-lite = "1.11"
 lazy_static = "1.4"

--- a/src/ucp/endpoint/mod.rs
+++ b/src/ucp/endpoint/mod.rs
@@ -128,7 +128,7 @@ impl Endpoint {
         worker: &Rc<Worker>,
         addr: SocketAddr,
     ) -> Result<Self, Error> {
-        let sockaddr = os_socketaddr::OsSocketAddr::from(addr);
+        let sockaddr = socket2::SockAddr::from(addr);
         #[allow(invalid_value)]
         #[allow(clippy::uninit_assumed_init)]
         let params = ucp_ep_params {

--- a/src/ucp/listener.rs
+++ b/src/ucp/listener.rs
@@ -40,9 +40,9 @@ impl ConnectionRequest {
         Error::from_status(status)?;
 
         let sockaddr = unsafe {
-            os_socketaddr::OsSocketAddr::from_raw_parts(&attr.client_address as *const _ as _, 8)
+            socket2::SockAddr::new(std::mem::transmute(attr.client_address), 8)
         };
-        Ok(sockaddr.into_addr().unwrap())
+        Ok(sockaddr.as_socket().unwrap())
     }
 }
 
@@ -58,7 +58,7 @@ impl Listener {
         }
         let (sender, recver) = mpsc::unbounded();
         let sender = Rc::new(sender);
-        let sockaddr = os_socketaddr::OsSocketAddr::from(addr);
+        let sockaddr = socket2::SockAddr::from(addr);
         let params = ucp_listener_params_t {
             field_mask: (ucp_listener_params_field::UCP_LISTENER_PARAM_FIELD_SOCK_ADDR
                 | ucp_listener_params_field::UCP_LISTENER_PARAM_FIELD_CONN_HANDLER)
@@ -97,10 +97,10 @@ impl Listener {
         let status = unsafe { ucp_listener_query(self.handle, &mut attr) };
         Error::from_status(status)?;
         let sockaddr = unsafe {
-            os_socketaddr::OsSocketAddr::from_raw_parts(&attr.sockaddr as *const _ as _, 8)
+            socket2::SockAddr::new(std::mem::transmute(attr.sockaddr), 8)
         };
 
-        Ok(sockaddr.into_addr().unwrap())
+        Ok(sockaddr.as_socket().unwrap())
     }
 
     /// Waiting for the next connection request.

--- a/src/ucp/listener.rs
+++ b/src/ucp/listener.rs
@@ -39,9 +39,8 @@ impl ConnectionRequest {
         let status = unsafe { ucp_conn_request_query(self.handle, &mut attr) };
         Error::from_status(status)?;
 
-        let sockaddr = unsafe {
-            socket2::SockAddr::new(std::mem::transmute(attr.client_address), 8)
-        };
+        let sockaddr =
+            unsafe { socket2::SockAddr::new(std::mem::transmute(attr.client_address), 8) };
         Ok(sockaddr.as_socket().unwrap())
     }
 }
@@ -96,9 +95,7 @@ impl Listener {
         };
         let status = unsafe { ucp_listener_query(self.handle, &mut attr) };
         Error::from_status(status)?;
-        let sockaddr = unsafe {
-            socket2::SockAddr::new(std::mem::transmute(attr.sockaddr), 8)
-        };
+        let sockaddr = unsafe { socket2::SockAddr::new(std::mem::transmute(attr.sockaddr), 8) };
 
         Ok(sockaddr.as_socket().unwrap())
     }


### PR DESCRIPTION
```
[1660803969.547104] [kv-client:377783:0]            sock.c:660  UCX  ERROR unknown address family: 10000
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidParam', examples/bench.rs:61:10
```

`os_socketaddr` seems buggy